### PR TITLE
Fix typo in pyproject.toml under tool.poetry.urls section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-[tool.petry.urls]
+[tool.poetry.urls]
 Homepage = "https://github.com/cel-ai/celai"
 Issues = "https://github.com/cel-ai/celai/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "celai"
+name = "cel"
 version = "0.1.0"
 description = ""
 authors = ["Alex Martin <alejamp@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "cel"
+name = "celai"
 version = "0.1.0"
 description = ""
 authors = ["Alex Martin <alejamp@gmail.com>"]
@@ -8,6 +8,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+]
+packages = [
+    { include = "cel" }
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Fix typo in pyproject.toml under tool.poetry.urls section


Changes:
- Corrected the typo in `pyproject.toml` from `[tool.petry.urls]` to `[tool.poetry.urls]`