### PR TITLE
Fix Custom Package Directory Handling and Typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-[tool.petry.urls]
+[tool.poetry.urls]
 Homepage = "https://github.com/cel-ai/celai"
 Issues = "https://github.com/cel-ai/celai/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "celai"
+name = "cel"
 version = "0.1.0"
 description = ""
 authors = ["Alex Martin <alejamp@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "cel"
+name = "celai"
 version = "0.1.0"
 description = ""
 authors = ["Alex Martin <alejamp@gmail.com>"]
@@ -8,6 +8,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+]
+packages = [
+    { include = "cel" }
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Fixes the handling of custom package directory name in the pyproject.toml file and corrects a typo in the [tool.poetry.urls] section.

# Problem:

* The current implementation of Poetry requires the main Python directory name to match the project name, which can lead to build failures if they are different. The project name is `celai` but the main Python directory is named `cel`, then build process fails.
* There was a typo in the configuration section [tool.poetry.urls], which was previously written as [tool.petry.urls].

# Solution:
* This PR introduces a new packages section in the [tool.poetry] configuration of pyproject.toml. This section allows users to specify custom package directory names.

```toml
[tool.poetry]
name = "celai"
version = "0.1.0"
description = ""
authors = ["Alex Martin <alejamp@gmail.com>"]
readme = "README.md"
classifiers = [
    "Programming Language :: Python :: 3",
    "License :: OSI Approved :: MIT License",
    "Operating System :: OS Independent",
]

# This fixes ModuleNotFoundError due to cel and celai names
packages = [
    { include = "cel" }
]

```
* Changed from `[tool.petry.urls]` to `[tool.poetry.urls]`
