### PR TITLE
Update macaw_nlp.py

### DIFF
--- a/cel/assistants/macaw/macaw_nlp.py
+++ b/cel/assistants/macaw/macaw_nlp.py
@@ -175,8 +175,6 @@ async def process_new_message(ctx: MacawNlpInferenceContext, message: str, on_fu
 
                             msg = ToolMessage(response_text, tool_call_id=id)
                             new_messages.append(msg)
-                            # Impact on history store
-                            await history_store.append_to_history(ctx.lead, msg)
                             log.debug(f"History udpated: func: {name} called with params: {args} -> {response_text}")
 
                         except Exception as e:
@@ -184,8 +182,6 @@ async def process_new_message(ctx: MacawNlpInferenceContext, message: str, on_fu
                             tool_output = "In this moment I can't process this request."
                             msg = ToolMessage(tool_output, tool_call_id=id)
                             new_messages.append(msg)
-                            # Impact on history store
-                            await history_store.append_to_history(ctx.lead, msg)
 
                             # break
                             # NOTE: If one function fails, the rest of the functions are not called?


### PR DESCRIPTION
This pull request includes a small change to the `cel/assistants/macaw/macaw_nlp.py` file. The change involves removing the calls to `history_store.append_to_history` to prevent updating the history store when processing new messages.

* [`cel/assistants/macaw/macaw_nlp.py`](diffhunk://#diff-448d70d34d9a356d4049a84e2f3986925f7a89c5df09f51c03bf57b2a8875fddL178-L188): Removed calls to `history_store.append_to_history` in the `process_new_message` function to avoid updating the history store with new messages.