### PR TITLE
Fix invitation guard invite

### DIFF
--- a/cel/middlewares/invitation_guard.py
+++ b/cel/middlewares/invitation_guard.py
@@ -447,11 +447,11 @@ class InvitationGuardMiddleware(ABC):
         url = None
         source = lead.connector_name
         
-        if source == "telegram":
+        if source.startswith("telegram:"):
             url = self.__gen_telegram_invitation_url(invitation.invite_code)
             qr = self.__gen_barcode(url)
         
-        if source == "whatsapp":
+        if source.startswith("whatsapp:"):
             url = self.__gen_whatsapp_invitation_url(invitation.invite_code)
             qr = self.__gen_barcode(url)
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "celai"
-version = "0.3.31"
+version = "0.3.32"
 description = "AI Driven Communication Platform. Assistants made easy."
 authors = ["Alex Martin <alejamp@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request includes changes to improve the handling of invitation URLs and a version update in the `pyproject.toml` file. The most important changes are:

### Improvements to invitation URL handling:

* [`cel/middlewares/invitation_guard.py`](diffhunk://#diff-3bab3329aa73d22a1d096559a0ba9195621b1bf81a96106d67634639f6308821L450-R454): Modified the `get_invitation_assets` method to use `startswith` for checking the source of the lead, ensuring that the correct invitation URL is generated for both Telegram and WhatsApp.

