### PR TITLE
Fix blend issue

### DIFF
--- a/cel/assistants/base_assistant.py
+++ b/cel/assistants/base_assistant.py
@@ -203,6 +203,7 @@ class BaseAssistant(ABC):
             args = inspect.getfullargspec(func).args
 
             ctx = FunctionContext(lead=lead, 
+                                  assistant=self,
                                   connector=connector, 
                                   state=self._state_store, 
                                   history=self._history_store)


### PR DESCRIPTION
Fix #68 
This pull request includes a small change to the `cel/assistants/base_assistant.py` file. The change adds the `assistant` parameter to the `FunctionContext` initialization in the `call_function` method.

* [`cel/assistants/base_assistant.py`](diffhunk://#diff-891b8e8e9a1ee0d6860876b7afc52d4a678f7b3577154c41f2314542244fceaaR206): Added `assistant=self` to the `FunctionContext` initialization in the `call_function` method.