### PR TITLE
Fix error in to_dict in WhatsappLead.py AttributeError("'dict' object has no attribute 'to_dict'")

### DIFF
--- a/cel/connectors/whatsapp/model/whatsapp_lead.py
+++ b/cel/connectors/whatsapp/model/whatsapp_lead.py
@@ -13,7 +13,29 @@ class WhatsappLead(ConversationLead):
         return f"{self.connector_name}:{self.phone}"  
 
     def to_dict(self):
-        data = super().to_dict()
+        try:
+            data = super().to_dict()
+        except AttributeError:
+            # If the parent's to_dict() method fails because an attribute
+            # is a dict instead of an object with to_dict(), construct our own dict
+            data = {}
+            # Add basic attributes from ConversationLead that might be needed
+            if hasattr(self, 'conversation_from'):
+                if hasattr(self.conversation_from, 'to_dict'):
+                    data['conversation_from'] = self.conversation_from.to_dict()
+                else:
+                    data['conversation_from'] = self.conversation_from
+            if hasattr(self, 'conversation_to'):
+                if hasattr(self.conversation_to, 'to_dict'):
+                    data['conversation_to'] = self.conversation_to.to_dict()
+                else:
+                    data['conversation_to'] = self.conversation_to
+            if hasattr(self, 'connector_name'):
+                data['connector_name'] = self.connector_name
+            if hasattr(self, 'metadata'):
+                data['metadata'] = self.metadata
+                
+        # Add WhatsappLead specific fields
         data['phone'] = self.phone
         return data
 


### PR DESCRIPTION
Code error example , error in line leadDict= lead.to_dict()
AttributeError("'dict' object has no attribute 'to_dict'")
```
async def handle_callback(lead: WhatsappLead, data: dict):
                try:
                    onboardingUtil = onboardingUtils()
                    #dict to json
                    leadDict= lead.to_dict()
                    phone = lead.phone
                    ## bussiness id = phone number not + in the number
                    bussinesId = phone.replace("+","")
                    ## Lead to Json
                    
                    validate_cip = ValidateCipInterface(
                        bussinesId=bussinesId,
                        phoneNumber=phone,
                        ticketId=data['ticketId'],
                        iproovToken=data['iproovToken'],
                        jwtToken=data['jwtToken'],
                        selected_address=data.get('selectedAddress'),
                        card_data=None,
                        lead=leadDict       
                    )
                    responseOnboarding = await onboardingUtil.validate_cip(validate_cip)
                    return {
                        "status": "success",
                        "message": "Callback received"
                    }
                except Exception as e:
                    return {
                        "status": "error",
                        "message": str(e)
                    }
```

This pull request includes changes to improve the robustness of the `to_dict` method in the `WhatsappLead` class within the `cel/connectors/whatsapp/model/whatsapp_lead.py` file. The main change involves handling potential `AttributeError` exceptions when calling the `super().to_dict()` method.

Error handling improvements:

* [`cel/connectors/whatsapp/model/whatsapp_lead.py`](diffhunk://#diff-8ea749391299429cc9b8bf39a20470df3e9036fe67bbcc14756688baff18dd6aR16-R38): Added a try-except block to catch `AttributeError` exceptions in the `to_dict` method. If an exception is caught, the method constructs a dictionary manually by checking for the presence of specific attributes and converting them to dictionaries if necessary. This ensures that the `to_dict` method can handle cases where attributes are dictionaries instead of objects with a `to_dict` method.