### PR TITLE
Rename ngrok environment var in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ export OPENAI_API_KEY=<YOUR_OPENAI_API_KEY>
 
 ### Ngrok Authtoken
 
-The easy way to get a public HTTPS URL for your assistant is to use [ngrok](https://ngrok.com/). Cel.ai has built-in support for ngrok, so you can easily delegate the public URL creation to Cel.ai. To use ngrok, you'll need a Ngrok authtoken. You can get one by signing up on the [ngrok website](https://ngrok.com/). Then set the `NGROK_AUTH_TOKEN` environment variable:
+The easy way to get a public HTTPS URL for your assistant is to use [ngrok](https://ngrok.com/). Cel.ai has built-in support for ngrok, so you can easily delegate the public URL creation to Cel.ai. To use ngrok, you'll need a Ngrok authtoken. You can get one by signing up on the [ngrok website](https://ngrok.com/). Then set the `NGROK_AUTHTOKEN` environment variable:
 
 ```bash
-export NGRO_AUTH_TOKEN=<YOUR_NGROK_AUTH_TOKEN>
+export NGROK_AUTHTOKEN=<YOUR_NGROK_AUTHTOKEN>
 ```
 
 Then you can create a new Python script with the following code, don't forget to

--- a/examples/11_moderation_demo/assistant.py
+++ b/examples/11_moderation_demo/assistant.py
@@ -14,7 +14,7 @@ Usage:
 ------
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
-- NGROK_AUTH_TOKEN: The ngrok authentication token for creating a public URL for your local server.
+- NGROK_AUTHTOKEN: The ngrok authentication token for creating a public URL for your local server.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 - OPENAI_API_KEY: The OpenAI API key for the assistant.
 

--- a/examples/12_insights/assistant.py
+++ b/examples/12_insights/assistant.py
@@ -14,7 +14,7 @@ Usage:
 ------
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
-- NGROK_AUTH_TOKEN: The ngrok authentication token for creating a public URL for your local server.
+- NGROK_AUTHTOKEN: The ngrok authentication token for creating a public URL for your local server.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 - OPENAI_API_KEY: The OpenAI API key for the assistant.
 

--- a/examples/13_agentic_router_experimental/assistant.py
+++ b/examples/13_agentic_router_experimental/assistant.py
@@ -14,7 +14,7 @@ Usage:
 ------
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
-- NGROK_AUTH_TOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
+- NGROK_AUTHTOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 - OPENAI_API_KEY: The OpenAI API key for the assistant. You can get this from the OpenAI dashboard.
 

--- a/examples/14_logic_router_experimental/assistant.py
+++ b/examples/14_logic_router_experimental/assistant.py
@@ -15,7 +15,7 @@ Usage:
 ------
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
-- NGROK_AUTH_TOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
+- NGROK_AUTHTOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 - OPENAI_API_KEY: The OpenAI API key for the assistant. You can get this from the OpenAI dashboard.
 

--- a/examples/15_voice/assistant.py
+++ b/examples/15_voice/assistant.py
@@ -15,7 +15,7 @@ Usage:
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
 
-- NGROK_AUTH_TOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
+- NGROK_AUTHTOKEN: The Ngrok authentication token. You can get this from the Ngrok dashboard.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 
 Also becuase this example uses the ElevenLabs and Deepgram APIs, you need to set the following environment variables:

--- a/examples/3_clerk_tooling/assistant.py
+++ b/examples/3_clerk_tooling/assistant.py
@@ -251,6 +251,6 @@ gateway.run(enable_ngrok=True)
 # if you want to use ngrok for testing, 
 # you can enable it by setting enable_ngrok=True
 # NOTE: Make sure you have ngrok installed in your system
-# and env variable NGROK_AUTH_TOKEN set with your ngrok token
+# and env variable NGROK_AUTHTOKEN set with your ngrok token
 # gateway.run(enable_ngrok=True)
 

--- a/examples/9_invitation_sample/assistant.py
+++ b/examples/9_invitation_sample/assistant.py
@@ -16,7 +16,7 @@ Usage:
 Configure the required environment variables in a .env file in the root directory of the project.
 The required environment variables are:
 
-- NGROK_AUTH_TOKEN: The ngrok authentication token for creating a public URL for your local server.
+- NGROK_AUTHTOKEN: The ngrok authentication token for creating a public URL for your local server.
 - TELEGRAM_TOKEN: The Telegram bot token for the assistant. You can get this from the BotFather on Telegram.
 - OPENAI_API_KEY: The OpenAI API key for the assistant.
 


### PR DESCRIPTION
This pull request rename the environment var in the project examples so that the assistants in the examples can find the right ngrok token.

[https://ngrok.com/docs/agent/#environment-variables](https://ngrok.com/docs/agent/#environment-variables) 