### PR TITLE
Expose Blend Prompt into assistant settings

### DIFF
--- a/cel/assistants/macaw/macaw_nlp.py
+++ b/cel/assistants/macaw/macaw_nlp.py
@@ -289,15 +289,22 @@ async def blend_message(ctx: MacawNlpInferenceContext, message: str, history_len
     for msg in msgs:
         dialog += f"{msg.type}: {msg.content}\n"
 
-    prompt1 = f"Given this conversation:\n{dialog}"
-    prompt2 = ("Elaborate this response in context to the user"
-               "(translate if needed to users lang, dont use markdown,"
-               f"dont include assistan: or user: labels): {message}")
 
-    # Prompt > System Message
-    messages = [SystemMessage(prompt1), SystemMessage(prompt2)]
+    system_message = ctx.settings.blend_prompt
 
-    res = llm.invoke(messages)
+    # Dynamically generated with current context and message:
+    prompt_message = (
+        f"Conversation context:\n{dialog}\n\n"
+        f"System message to adapt:\n\"{message}\""
+    )
+
+    # Using standard langchain or similar LLM message format:
+    messages = [
+        SystemMessage(system_message),
+        HumanMessage(prompt_message)
+    ]
+
+    res = llm.invoke(messages)    
 
     return res.content
 

--- a/cel/assistants/macaw/macaw_settings.py
+++ b/cel/assistants/macaw/macaw_settings.py
@@ -34,6 +34,13 @@ class MacawSettings:
     blend_timeout: int = 20
     """The timeout to use for the blend processing."""
     blend_max_retries: int = 3
+    """Blend custom prompt"""
+    blend_prompt: str = (
+        "You are responsible for clearly rewriting and adapting technical system messages "
+        "into natural, user-friendly text. Translate the messages according to the user's language "
+        "and conversational tone. Do not include markdown, technical labels (e.g. user:, assistant:). "
+        "Adapt the wording and style to match naturally with conversational context."
+    )
 
     insights_enabled: bool = True
     """Whether to enable the insights processing."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "celai"
-version = "0.4.4"
+version = "0.4.5"
 description = "AI Driven Communication Platform. Assistants made easy."
 authors = ["Alex Martin <alejamp@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
This pull request introduces improvements to the `blend_message` function in `macaw_nlp.py` to enhance message adaptation and user-friendliness, adds a customizable blend prompt in `macaw_settings.py`, and updates the project version in `pyproject.toml`.

**Example code:**
```python
from cel.assistants.macaw.macaw_settings import MacawSettings

prompt = "You are a Q&A Assistant. Called Celia."
prompt_template = PromptTemplate(prompt)

ast = MacawAssistant(
    prompt=prompt_template,

    # Customize blend prompt: 
    settings=MacawSettings(
        blend_prompt="""You are responsible for clearly rewriting and adapting technical system messages"""
    )
)
```

### Enhancements to message blending:
* [`cel/assistants/macaw/macaw_nlp.py`](diffhunk://#diff-448d70d34d9a356d4049a84e2f3986925f7a89c5df09f51c03bf57b2a8875fddL292-R305): Refactored the `blend_message` function to use a dynamically generated prompt message and a system message defined in the settings. The updated implementation leverages a more structured LLM message format (`SystemMessage` and `HumanMessage`) for better adaptability.

### Configuration updates:
* [`cel/assistants/macaw/macaw_settings.py`](diffhunk://#diff-2e7c4f5a801c9116d7097071f695006b396311ec19a0604318d6dfdd56e64c6aR37-R43): Added a new `blend_prompt` setting in the `MacawSettings` class to define a reusable system message for adapting technical messages into user-friendly text.

### Project metadata update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version from `0.4.4` to `0.4.5`.
