### PR TITLE
✨ Add LiveKit Connector Integration for Real-Time Voice Communication

### DIFF
--- a/cel/connectors/livekit/livekit_adapter.py
+++ b/cel/connectors/livekit/livekit_adapter.py
@@ -106,7 +106,7 @@ class LiveKitStream(llm.LLMStream):
             input_text = None
             for m in reversed(self.chat_ctx.items):
                 if m.role == "user":
-                    print(f"User message found: {m}")
+                    log.debug(f"User message found: {m}")
                     input_text = self._to_message(m)
                     break
             

--- a/cel/connectors/livekit/livekit_adapter.py
+++ b/cel/connectors/livekit/livekit_adapter.py
@@ -43,11 +43,10 @@ class LiveKitStream(llm.LLMStream):
         session_id: str,
         api_url: str,
         timeout: float = 30.0,
-        tools: Optional[List[FunctionTool]] = None,     # 👈 reemplaza fnc_ctx
+        tools: Optional[List[FunctionTool]] = None,
         conn_options: APIConnectOptions | None = None,
         **kwargs,
     ):
-        # ⬇️  API nueva: tools en vez de fnc_ctx
         super().__init__(llm, chat_ctx=chat_ctx, tools=tools, conn_options=conn_options)
         self._session_id = session_id
         self._api_url = api_url
@@ -60,7 +59,7 @@ class LiveKitStream(llm.LLMStream):
         *,
         id: str | None = None,
     ) -> llm.ChatChunk:
-        """Genera un ChatChunk con el nuevo esquema (id + delta)."""
+        """Generates a ChatChunk with the new schema (id + delta)."""
         return llm.ChatChunk(
             id=id or shortuuid(),
             delta=llm.ChoiceDelta(role="assistant", content=content),
@@ -212,7 +211,6 @@ class LiveKitAdapter(llm.LLM):
         chat_ctx: llm.ChatContext,
         tools: list[FunctionTool] | None = None,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
-        # N extra params
         **kwargs: Any,
         
     ) -> llm.LLMStream:

--- a/cel/connectors/livekit/livekit_adapter.py
+++ b/cel/connectors/livekit/livekit_adapter.py
@@ -1,0 +1,267 @@
+"""
+LiveKitAdapter masquerades as a livekit.LLM and communicates with Celai
+through HTTP API calls.
+"""
+
+from typing import Dict, Optional, Any
+from loguru import logger as log
+
+# If livekit-agents not installed raise ImportError
+try:
+    from livekit.agents import llm
+    from livekit.agents.tts import SynthesizeStream
+    from livekit.agents.types import APIConnectOptions, DEFAULT_API_CONNECT_OPTIONS
+    from livekit.agents.utils import shortuuid
+except ImportError:
+    raise ImportError(
+        "LiveKit agents library not installed. Please install it using 'pip install livekit-agents'."
+    )
+
+
+import httpx
+
+
+class FlushSentinel(str, SynthesizeStream._FlushSentinel):
+    """
+    A sentinel object that indicates when to flush the stream.
+    """
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls, *args, **kwargs)
+
+
+class LiveKitStream(llm.LLMStream):
+    """
+    Stream implementation for LiveKit that handles communication with Celai API.
+    """
+    
+    def __init__(
+        self,
+        llm: llm.LLM,
+        chat_ctx: llm.ChatContext,
+        session_id: str,
+        api_url: str,
+        timeout: float = 30.0,
+        fnc_ctx: Optional[Dict] = None,
+        conn_options: APIConnectOptions = None,
+        **kwargs
+    ):
+        """
+        Initialize the LiveKit stream.
+        
+        Args:
+            llm: The LLM instance
+            chat_ctx: The chat context from LiveKit
+            session_id: The session ID for this conversation
+            api_url: URL for the Celai API endpoint
+            timeout: Timeout for HTTP requests in seconds
+            fnc_ctx: The function context from LiveKit
+            conn_options: Connection options from LiveKit
+            **kwargs: Additional parameters to pass to the API
+        """
+        super().__init__(
+            llm, chat_ctx=chat_ctx, fnc_ctx=fnc_ctx, conn_options=conn_options
+        )
+        self._session_id = session_id
+        self._api_url = api_url
+        self._timeout = timeout
+        self._kwargs = kwargs
+    
+    def _to_message(self, msg: llm.ChatMessage) -> str:
+        """
+        Convert a LiveKit ChatMessage to text.
+        
+        Args:
+            msg: The LiveKit chat message
+            
+        Returns:
+            The extracted text from the message
+        """
+        if isinstance(msg.content, str):
+            return msg.content
+        elif isinstance(msg.content, list):
+            text_parts = []
+            for c in msg.content:
+                if isinstance(c, str):
+                    text_parts.append(c)
+                elif isinstance(c, dict) and c.get("type") == "text":
+                    text_parts.append(c.get("text", ""))
+                elif hasattr(c, "text"):
+                    text_parts.append(c.text)
+            return " ".join(text_parts)
+        return ""
+    
+    @staticmethod
+    def _create_livekit_chunk(content: str, *, id: str | None = None) -> llm.ChatChunk | None:
+        """
+        Create a LiveKit chat chunk from content.
+        
+        Args:
+            content: The content to include in the chunk
+            id: Optional ID for the chunk
+            
+        Returns:
+            A LiveKit chat chunk
+        """
+        return llm.ChatChunk(
+            request_id=id or shortuuid(),
+            choices=[
+                llm.Choice(delta=llm.ChoiceDelta(role="assistant", content=content))
+            ],
+        )
+    
+    async def _to_livekit_chunk(self, content: str | Any) -> llm.ChatChunk | None:
+        """
+        Convert text content to a LiveKit chat chunk.
+        
+        Args:
+            content: The content to convert
+            
+        Returns:
+            A LiveKit chat chunk or None if the content is invalid
+        """
+        if not content:
+            return None
+        
+        request_id = None
+        if hasattr(content, 'id'):
+            request_id = content.id
+        
+        if isinstance(content, str):
+            return self._create_livekit_chunk(content, id=request_id)
+        elif isinstance(content, dict) and "content" in content:
+            return self._create_livekit_chunk(content["content"], id=content.get("id", request_id))
+        
+        return None
+    
+    async def _run(self):
+        """Process the incoming message and stream the response"""
+        try:
+            # Find the most recent user message
+            input_text = None
+            for m in reversed(self.chat_ctx.messages):
+                if m.role == "user":
+                    input_text = self._to_message(m)
+                    break
+            
+            if not input_text:
+                log.warning("No user message found in chat context")
+                return
+            
+            log.debug(f"Processing via API for session {self._session_id}")
+            
+            # Prepare the request payload
+            payload = {
+                "session_id": self._session_id,
+                "user_text": input_text,
+                **self._kwargs
+            }
+            
+            # Make the request and stream the response
+            async with httpx.AsyncClient() as client:
+                async with client.stream(
+                    "POST",
+                    self._api_url,
+                    json=payload,
+                    timeout=self._timeout,
+                ) as response:
+                    # Check for successful response
+                    if response.status_code != 200:
+                        err_txt = await response.text()
+                        raise RuntimeError(f"API error => status {response.status_code}: {err_txt}")
+
+                    # Process the response line by line
+                    async for line in response.aiter_lines():
+                        if line.startswith("data: "):
+                            content = line.removeprefix("data: ").strip()
+
+                            # Check for flush sentinel
+                            if content == str(FlushSentinel()):
+                                self._event_ch.send_nowait(
+                                    self._create_livekit_chunk(FlushSentinel())
+                                )
+                            elif content:  # Skip empty content
+                                chunk = await self._to_livekit_chunk(content)
+                                if chunk:
+                                    self._event_ch.send_nowait(chunk)
+
+                    # End of stream
+                    self._event_ch.send_nowait(
+                        self._create_livekit_chunk(FlushSentinel())
+                    )
+                
+        except Exception as e:
+            log.error(f"Error in LiveKitStream._run: {e}")
+            error_message = f"Error processing your request: {str(e)}"
+            if chunk := await self._to_livekit_chunk(error_message):
+                self._event_ch.send_nowait(chunk)
+            
+            # Always send a flush sentinel on error to ensure the stream completes
+            self._event_ch.send_nowait(
+                self._create_livekit_chunk(FlushSentinel())
+            )
+
+
+class LiveKitAdapter(llm.LLM):
+    """
+    Adapter class that implements LiveKit's LLM interface
+    and delegates to Celai API for actual processing.
+    """
+    
+    def __init__(
+        self, 
+        api_url: str,
+        timeout: float = 30.0,
+        **kwargs
+    ):
+        """
+        Initialize the adapter with parameters for API communication.
+        
+        Args:
+            api_url: URL for the Celai API endpoint
+            timeout: Timeout for HTTP requests in seconds
+            **kwargs: Additional parameters to pass to the API
+        """
+        super().__init__()
+        
+        # Store configuration
+        self._api_url = api_url
+        self._timeout = timeout
+        self._kwargs = kwargs
+        
+        log.info(f"Initialized LiveKitAdapter using API URL: {api_url}")
+    
+    def chat(
+        self,
+        chat_ctx: llm.ChatContext,
+        fnc_ctx: llm.FunctionContext,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+    ) -> llm.LLMStream:
+        """
+        Create a stream for LiveKit chat.
+        
+        This method is called by LiveKit to process a message and get a response.
+        
+        Args:
+            chat_ctx: The chat context from LiveKit
+            fnc_ctx: The function context from LiveKit
+            conn_options: Connection options from LiveKit
+            
+        Returns:
+            A LiveKit stream for handling the chat
+        """
+        # Extract a stable session ID from the chat context
+        # Using the first message ID as a base to ensure consistency
+        base_id = chat_ctx.messages[0].id if chat_ctx.messages else shortuuid()
+        session_id = f"livekit:{base_id}"
+        
+        # Return a stream that will process the message
+        return LiveKitStream(
+            llm=self,
+            chat_ctx=chat_ctx,
+            session_id=session_id,
+            api_url=self._api_url,
+            timeout=self._timeout,
+            fnc_ctx=fnc_ctx,
+            conn_options=conn_options,
+            **self._kwargs
+        )

--- a/cel/connectors/livekit/livekit_connector.py
+++ b/cel/connectors/livekit/livekit_connector.py
@@ -1,3 +1,12 @@
+""" LIVEKIT Connector
+    This connector is designed to work with LiveKit, a WebRTC platform for real-time communication.
+    It provides a FastAPI router for handling chat completions and streaming responses.
+
+    This connector will use DIRECT stream mode to send messages to the platform. Core events,
+    and Middleware events are available.
+"""
+
+
 from fastapi.responses import StreamingResponse
 from loguru import logger as log
 from fastapi import APIRouter, BackgroundTasks, Request
@@ -5,7 +14,6 @@ from cel.gateway.model.base_connector import BaseConnector
 from cel.gateway.model.message_gateway_context import MessageGatewayContext
 from cel.connectors.livekit.model.livekit_message import LiveKitMessage
 from cel.gateway.message_gateway import StreamMode
-from cel.gateway.model.stream_content_chunk import StreamContentChunk
 from cel.gateway.model.outgoing import OutgoingMessage
 
 class LiveKitConnector(BaseConnector):
@@ -37,11 +45,8 @@ class LiveKitConnector(BaseConnector):
             msg = await LiveKitMessage.load_from_message(payload, connector=self)
             
             if self.gateway:
-                # Use a buffer to accumulate chunks and handle spacing properly
-                current_partial = ""
-                
+            
                 async for chunk in self.gateway.process_message(msg, mode=StreamMode.DIRECT, capture_repsonse=True):
-                    assert isinstance(chunk, StreamContentChunk), "stream chunk must be a StreamContentChunk object"
                     
                     # Send the content with proper formatting
                     if chunk.content:

--- a/cel/connectors/livekit/livekit_connector.py
+++ b/cel/connectors/livekit/livekit_connector.py
@@ -1,0 +1,91 @@
+from fastapi.responses import StreamingResponse
+from loguru import logger as log
+from fastapi import APIRouter, BackgroundTasks, Request
+from cel.gateway.model.base_connector import BaseConnector
+from cel.gateway.model.message_gateway_context import MessageGatewayContext
+from cel.connectors.livekit.model.livekit_message import LiveKitMessage
+from cel.gateway.message_gateway import StreamMode
+from cel.assistants.stream_content_chunk import StreamContentChunk
+from cel.gateway.model.outgoing import OutgoingMessage
+
+class LiveKitConnector(BaseConnector):
+    """
+    LiveKit connector that provides a FastAPI router for handling chat completions.
+    """
+    
+    endpoint = '/chat/completions'
+    
+    def __init__(self):
+        log.debug("Creating LiveKit connector")
+        self.prefix = '/livekit'
+        self.router = APIRouter(prefix=self.prefix)
+        self.paused = False
+        self.__create_routes(self.router)
+    
+    def __create_routes(self, router: APIRouter):
+
+        @router.post(f"{LiveKitConnector.endpoint}")
+        async def chat_completion(request: Request, background_tasks: BackgroundTasks):
+            data = await request.json()
+            log.debug(f"[LiveKit] Incoming JSON: {data}")
+            return StreamingResponse(self.__process_stream(data), media_type='text/event-stream')
+
+    async def __process_stream(self, payload: dict):
+        try:
+            log.debug(f"Received LiveKit text for Stream Processing: {payload}")
+
+            msg = await LiveKitMessage.load_from_message(payload, connector=self)
+
+            if self.gateway:
+                async for chunk in self.gateway.process_message(msg, mode=StreamMode.DIRECT, capture_repsonse=True):
+                    assert isinstance(chunk, StreamContentChunk), "stream chunk must be a StreamContentChunk object"
+                    yield f"data: {chunk.content}\n\n"
+                
+            # end of stream
+            yield f"data: \n\n"
+
+        except Exception as e:
+            log.error(f"Error processing LiveKit stream: {e}")
+            yield f"data: Error: {str(e)}\n\n"
+
+    async def send_typing_action(self, lead):
+        log.warning("send_typing_action must be implemented in LiveKit connector")
+    
+    async def send_message(self, message: OutgoingMessage):
+        log.warning("send_message must be implemented in LiveKit connector")
+    
+    def name(self) -> str:
+        return "livekit"
+    
+    def get_router(self) -> APIRouter:
+        return self.router
+    
+    def set_gateway(self, gateway):
+        from cel.gateway.message_gateway import MessageGateway
+        assert isinstance(gateway, MessageGateway), \
+            "gateway must be an instance of MessageGateway"
+        self.gateway = gateway
+
+    def startup(self, context: MessageGatewayContext):
+        # verify if the webhook_url is set and is HTTPS
+        assert context.webhook_url, "webhook_url must be set in the context"
+        assert context.webhook_url.startswith("https"),\
+            f"webhook_url must be HTTPS, got: {context.webhook_url}.\
+            Be sure that your url is public and has a valid SSL certificate."
+        
+        webhook_url = f"{context.webhook_url}{self.prefix}{LiveKitConnector.endpoint}"
+        log.debug(f"Starting LiveKit connector with url: {webhook_url}")
+        log.debug("Be sure to setup this url in the LiveKit Assistant, \
+            go to Assistant Settings -> Model and select Custom LLM.\
+            Then set the url in the Custom LLM URL field")
+
+    def shutdown(self, context: MessageGatewayContext):
+        log.debug("Shutting down LiveKit connector")
+    
+    def pause(self):
+        log.debug("Pausing LiveKit connector")
+        self.paused = True
+
+    def resume(self):
+        log.debug("Resuming LiveKit connector")
+        self.paused = False

--- a/cel/connectors/livekit/livekit_connector.py
+++ b/cel/connectors/livekit/livekit_connector.py
@@ -5,7 +5,7 @@ from cel.gateway.model.base_connector import BaseConnector
 from cel.gateway.model.message_gateway_context import MessageGatewayContext
 from cel.connectors.livekit.model.livekit_message import LiveKitMessage
 from cel.gateway.message_gateway import StreamMode
-from cel.assistants.stream_content_chunk import StreamContentChunk
+from cel.gateway.model.stream_content_chunk import StreamContentChunk
 from cel.gateway.model.outgoing import OutgoingMessage
 
 class LiveKitConnector(BaseConnector):
@@ -20,10 +20,10 @@ class LiveKitConnector(BaseConnector):
         self.prefix = '/livekit'
         self.router = APIRouter(prefix=self.prefix)
         self.paused = False
+        self.gateway = None
         self.__create_routes(self.router)
     
     def __create_routes(self, router: APIRouter):
-
         @router.post(f"{LiveKitConnector.endpoint}")
         async def chat_completion(request: Request, background_tasks: BackgroundTasks):
             data = await request.json()
@@ -32,16 +32,26 @@ class LiveKitConnector(BaseConnector):
 
     async def __process_stream(self, payload: dict):
         try:
-            log.debug(f"Received LiveKit text for Stream Processing: {payload}")
+            log.debug(f"[LiveKit] Processing stream with payload: {payload}")
 
             msg = await LiveKitMessage.load_from_message(payload, connector=self)
-
+            
             if self.gateway:
+                # Use a buffer to accumulate chunks and handle spacing properly
+                current_partial = ""
+                
                 async for chunk in self.gateway.process_message(msg, mode=StreamMode.DIRECT, capture_repsonse=True):
                     assert isinstance(chunk, StreamContentChunk), "stream chunk must be a StreamContentChunk object"
-                    yield f"data: {chunk.content}\n\n"
-                
-            # end of stream
+                    
+                    # Send the content with proper formatting
+                    if chunk.content:
+                        yield f"data: {chunk.content}\n\n"
+                    
+                    # If this is the end of a partial chunk, add the flush sentinel
+                    if not chunk.is_partial:
+                        yield f"data: <FLUSH>\n\n"
+            
+            # End of stream
             yield f"data: \n\n"
 
         except Exception as e:
@@ -49,10 +59,14 @@ class LiveKitConnector(BaseConnector):
             yield f"data: Error: {str(e)}\n\n"
 
     async def send_typing_action(self, lead):
-        log.warning("send_typing_action must be implemented in LiveKit connector")
+        # LiveKit doesn't support typing indicators
+        log.debug("Typing indicators not supported in LiveKit")
+        pass
     
     async def send_message(self, message: OutgoingMessage):
-        log.warning("send_message must be implemented in LiveKit connector")
+        # This method is not needed for the streaming interface
+        log.debug("Direct message sending not used in LiveKit connector")
+        pass
     
     def name(self) -> str:
         return "livekit"
@@ -67,17 +81,17 @@ class LiveKitConnector(BaseConnector):
         self.gateway = gateway
 
     def startup(self, context: MessageGatewayContext):
-        # verify if the webhook_url is set and is HTTPS
-        assert context.webhook_url, "webhook_url must be set in the context"
-        assert context.webhook_url.startswith("https"),\
-            f"webhook_url must be HTTPS, got: {context.webhook_url}.\
-            Be sure that your url is public and has a valid SSL certificate."
+        # Verify if the webhook_url is set and is HTTPS
+        if not context.webhook_url:
+            log.warning("webhook_url is not set in the context - make sure your endpoint is accessible")
+            return
+            
+        if not context.webhook_url.startswith("https"):
+            log.warning(f"webhook_url should be HTTPS for production, got: {context.webhook_url}")
         
         webhook_url = f"{context.webhook_url}{self.prefix}{LiveKitConnector.endpoint}"
-        log.debug(f"Starting LiveKit connector with url: {webhook_url}")
-        log.debug("Be sure to setup this url in the LiveKit Assistant, \
-            go to Assistant Settings -> Model and select Custom LLM.\
-            Then set the url in the Custom LLM URL field")
+        log.info(f"Starting LiveKit connector with endpoint: {webhook_url}")
+        log.info("Use this URL in the LiveKit Assistant settings under Model → Custom LLM URL")
 
     def shutdown(self, context: MessageGatewayContext):
         log.debug("Shutting down LiveKit connector")

--- a/cel/connectors/livekit/model/livekit_lead.py
+++ b/cel/connectors/livekit/model/livekit_lead.py
@@ -1,0 +1,24 @@
+from cel.gateway.model.conversation_lead import ConversationLead
+from cel.gateway.model.conversation_peer import ConversationPeer
+
+
+class LiveKitLead(ConversationLead):
+    """ LiveKitLead class."""
+
+    def __init__(self, call_object: dict, **kwargs):
+        super().__init__(connector_name="livekit", **kwargs)
+        self.call_object: dict = call_object
+
+    def get_session_id(self):
+        return f"{self.connector_name}:{self.call_object['session_id']}"
+    
+    @classmethod
+    def from_message(cls, message: dict, **kwargs):
+        conversation_peer = ConversationPeer(
+            name='Unknown',
+            id=message['session_id'],
+            phone=None,
+            avatarUrl=None,
+            email=None,
+        )
+        return LiveKitLead(call_object=message, conversation_from=conversation_peer, **kwargs)

--- a/cel/connectors/livekit/model/livekit_message.py
+++ b/cel/connectors/livekit/model/livekit_message.py
@@ -1,0 +1,51 @@
+from cel.gateway.model.message import Message
+from cel.gateway.model.conversation_lead import ConversationLead
+from cel.gateway.model.base_connector import BaseConnector
+from cel.connectors.livekit.model.livekit_lead import LiveKitLead
+from loguru import logger as log
+
+class LiveKitMessage(Message):
+    """
+    LiveKitMessage class to represent a message in the LiveKit connector.
+    """
+
+    def __init__(self, lead: ConversationLead, text: str = None):
+        """
+        Initialize the LiveKitMessage instance.
+
+        Args:
+            lead (ConversationLead): The lead associated with the message.
+            text (str): The text of the message.
+        """
+        super().__init__(lead, text=text)
+
+    def is_voice_message(self):
+        return False
+    
+    @classmethod
+    async def load_from_message(cls, request, connector: BaseConnector = None):
+        """
+        Load a LiveKitMessage from a message dictionary.
+
+        Args:
+            message_dict (dict): The message dictionary.
+            token (str): The token for authentication.
+            connector: The connector instance.
+
+        Returns:
+            LiveKitMessage: The loaded LiveKitMessage instance.
+        """
+        log.debug(f"[LiveKit] Raw request in load_from_message: {request}")
+        user_message = request.get("user_text")
+        
+        if not user_message:
+            raise ValueError("No message found in the message_dict")
+
+        lead = LiveKitLead.from_message(request, connector=connector)
+        return LiveKitMessage(lead=lead, text=user_message)
+    
+    def __str__(self):
+        return f"LiveKitMessage: {self.text}"
+    
+    def __repr__(self):
+        return f"LiveKitMessage: {self.text}"

--- a/cel/connectors/livekit/model/livekit_message.py
+++ b/cel/connectors/livekit/model/livekit_message.py
@@ -1,8 +1,8 @@
+from loguru import logger as log
 from cel.gateway.model.message import Message
 from cel.gateway.model.conversation_lead import ConversationLead
 from cel.gateway.model.base_connector import BaseConnector
 from cel.connectors.livekit.model.livekit_lead import LiveKitLead
-from loguru import logger as log
 
 class LiveKitMessage(Message):
     """


### PR DESCRIPTION
# Overview
This PR introduces a new LiveKit connector to the Celai platform, enabling seamless integration with [LiveKit](https://livekit.io/) for real-time voice-based agent interactions. This includes full support for streaming chat completions, Celai-compatible session handling, and token-based output chunking.

# 📂 Key Additions

`cel/connectors/livekit/livekit_connector.py`
* Implements the LiveKitConnector class derived from BaseConnector.
* Exposes a FastAPI router (/livekit/chat/completions) with support for SSE streaming using StreamingResponse.
* Integrates with Celai’s MessageGateway to handle input and return processed outputs in DIRECT stream mode.

`cel/connectors/livekit/livekit_adapter.py`
* Implements LiveKitAdapter, an LLM subclass compatible with the LiveKit agents interface.
* Defines LiveKitStream, which sends Celai API requests and parses streamed responses line-by-line.
* Sends tokens and flush markers ("<FLUSH>") according to LiveKit streaming protocol.
* Handles errors gracefully and guarantees a flush marker is always sent on stream termination.

`cel/connectors/livekit/model/livekit_message.py`
* Adds LiveKitMessage, a subclass of Message.
* Implements `load_from_message()` to convert incoming JSON into Celai message format.
* Includes debug logging for raw request inspection.

`cel/connectors/livekit/model/livekit_lead.py`
* Adds LiveKitLead, a subclass of ConversationLead.
* Implements `get_session_id()` using LiveKit's session_id.
* Includes `from_message()` helper to generate a conversation peer object with basic metadata.

# ✅ Features

* Full support for LiveKit’s streaming LLM API.
* Compatible with Celai's MessageGateway and assistant architecture.
* FastAPI integration with SSE for real-time message delivery.
* Graceful error handling and flush signaling.
* Lightweight and isolated – does not impact other connectors.

# 🔧 Usage

1. Install the required dependencies in the LiveKit worker **(no need on celai host)**
`pip install livekit-agents httpx`

2. Start your Celai server with the LiveKit connector enabled.

3. In your LiveKit Agent configuration, set the llm to:

```python
# ... Agent code
celai_llm = LiveKitAdapter(api_url="https://<your-host>/livekit/chat/completions")
session = AgentSession(
    stt=deepgram.STT(language="es", model="nova-2-general"),
    llm=celai_llm,
    tts=aws.TTS(voice="Lupe", speech_engine="generative"),
    vad=vad_model,
    )
```

# ℹ️ Notes

* The connector streams raw text content as `data:` SSE lines.
* `<FLUSH>` markers are used to signal the end of message segments.